### PR TITLE
shim Object.assign

### DIFF
--- a/src/assign.js
+++ b/src/assign.js
@@ -1,0 +1,9 @@
+export default function assign(object, ...objects) {
+  for (let i = 0; i < objects.length; i++) {
+    let hash = objects[i];
+    for (let key in hash) {
+      object[key] = hash[key];
+    }
+  }
+  return object;
+}

--- a/src/progress.js
+++ b/src/progress.js
@@ -1,3 +1,5 @@
+import assign from './assign';
+
 export default class Progress {
   constructor(target, options = {observe: ()=> {}}) {
     this.observe = options.observe;
@@ -32,7 +34,7 @@ export default class Progress {
 
 class State {
   constructor(previous = {}, change = ()=> {}) {
-    Object.assign(this, {
+    assign(this, {
       abort: null,
       error: null,
       loadStart: null,
@@ -43,7 +45,7 @@ class State {
     if (change.call) {
       change(this);
     } else {
-      Object.assign(this, change);
+      assign(this, change);
     }
     if (this.freeze !== false) {
       Object.freeze(this.progress);

--- a/src/x-request.js
+++ b/src/x-request.js
@@ -1,4 +1,5 @@
 import Progress from './progress';
+import assign from './assign';
 
 export default class XRequest {
   constructor(options = {}) {
@@ -64,7 +65,7 @@ export default class XRequest {
 
 class State {
   constructor(previous = {}, change = ()=> {}) {
-    Object.assign(this, previous, {
+    assign(this, previous, {
       readyState: previous.xhr.readyState,
       status: previous.xhr.status,
       response: previous.xhr.response
@@ -77,7 +78,7 @@ class State {
     if (change.call) {
       change(this);
     } else {
-      Object.assign(this, change);
+      assign(this, change);
     }
     if (this.freeze !== false) {
       Object.freeze(this);


### PR DESCRIPTION
Not all browsers, including PhantomJS, have Object.assign. Rather than
depending on a Babel polyfill or something, we include it with the
library.
